### PR TITLE
fix tf serving repo url

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -21,7 +21,7 @@ services:
         max-file: "10"
 
   serving:
-    image: gcr.io/automl-vision-ondevice/gcloud-container-1.12.0:latest
+    image: gcr.io/cloud-devrel-public-resources/gcloud-container-1.14.0:latest
     ports:
       - 8501:8501
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         max-file: "10"
 
   serving:
-    image: gcr.io/automl-vision-ondevice/gcloud-container-1.12.0:latest
+    image: gcr.io/cloud-devrel-public-resources/gcloud-container-1.14.0:latest
     ports:
       - 8501:8501
     volumes:


### PR DESCRIPTION
Looks like some bold guys at google broke things by moving docker image to a new url 👍