### PR TITLE
fix mongo version

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -34,7 +34,7 @@ services:
         max-file: "10"
 
   mongo:
-    image: mongo
+    image: mongo:4.2.15
     ports:
       - 27017:27017
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
         max-file: "10"
 
   mongo:
-    image: mongo
+    image: mongo:4.2.15
     volumes:
       - /opt/mongo/data/db:/data/db
     env_file:


### PR DESCRIPTION
explicit is better than implicit, or:

Wrong mongod version","attr":{"error":"UPGRADE PROBLEM: Found an invalid featureCompatibilityVersion document (ERROR: Location4926900: Invalid featureCompatibilityVersion document in admin.system.version: { _id: \"featureCompatibilityVersion\", version: \"4.2\" }. See https://docs.mongodb.com/master/release-notes/4.4-compatibility/#feature-compatibility. :: caused by :: Invalid value for featureCompatibilityVersiondocument in admin.system.version, found 4.2, expected '4.4' or '4.9' or '5.0. See https://docs.mongodb.com/master/release-notes/4.4-compatibility/#feature-compatibility.). If the current featureCompatibilityVersion is below 4.4, see the documentation on upgrading at https://docs.mongodb.com/master/release-notes/4.4/#upgrade-procedures.