### PR TITLE
do not wipe messages that were replied with the command

### DIFF
--- a/bot/skills/ban.py
+++ b/bot/skills/ban.py
@@ -29,5 +29,5 @@ def ban(update: Union[str, Update], context: CallbackContext):
             result,
             600,
             remove_cmd=True,
-            remove_reply=True,
+            remove_reply=False,
         )

--- a/bot/skills/coc.py
+++ b/bot/skills/coc.py
@@ -26,5 +26,5 @@ def coc(update: Update, context: CallbackContext):
         result,
         600,
         remove_cmd=True,
-        remove_reply=True,
+        remove_reply=False,
     )

--- a/bot/skills/mute.py
+++ b/bot/skills/mute.py
@@ -91,7 +91,7 @@ def mute_self(update: Update, context: CallbackContext):
         result,
         600,
         remove_cmd=True,
-        remove_reply=True,
+        remove_reply=False,
     )
 
 

--- a/bot/skills/prism.py
+++ b/bot/skills/prism.py
@@ -111,5 +111,5 @@ def show_top(update: Update, context: CallbackContext):
         result,
         600,
         remove_cmd=True,
-        remove_reply=True,
+        remove_reply=False,
     )

--- a/bot/skills/roll.py
+++ b/bot/skills/roll.py
@@ -315,7 +315,7 @@ def show_hussars(update: Update, context: CallbackContext):
         result,
         600,
         remove_cmd=True,
-        remove_reply=True,
+        remove_reply=False,
     )
 
     os.remove(board_image_path)
@@ -417,7 +417,7 @@ def satisfy_GDPR(update: Update, context: CallbackContext):
         result,
         120,
         remove_cmd=True,
-        remove_reply=True,
+        remove_reply=False,
     )
 
 
@@ -432,5 +432,5 @@ def wipe_hussars(update: Update, context: CallbackContext):
         result,
         120,
         remove_cmd=True,
-        remove_reply=True,
+        remove_reply=False,
     )


### PR DESCRIPTION
Fix for the bug when any user can wipe any other user's messages by issuing a command as a reply to the message.

E.g.:
Greta: Hello, I am Greta!
Grinch (replying to Greta's message): /70k
Nyan: blah blah show me the money
....
60 seconds later Nyan wipes it's "blah blah" as well as original Greta's message that Grich replied to with malicious intentions (obviously).