### PR TITLE
Remove redundant parse markdown in peninsula mode

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [[description]]
 name = "vldc-bot"
-version = "0.6.9"
+version = "0.6.10"
 description = "VLDC nyan bot ^_^"
 authors = [
     #tg

--- a/bot/skills/length.py
+++ b/bot/skills/length.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional, List, TypedDict
 
-from telegram import Update, User, Message, ParseMode
+from telegram import Update, User, Message
 from telegram.ext import Updater, CommandHandler, CallbackContext
 from telegram.ext.filters import Filters
 

--- a/bot/skills/length.py
+++ b/bot/skills/length.py
@@ -107,7 +107,6 @@ def _longest(update: Update, context: CallbackContext):
     result: Optional[Message] = context.bot.send_message(
         update.effective_chat.id,
         message,
-        parse_mode=ParseMode.MARKDOWN_V2,
         disable_notification=True,
     )
 


### PR DESCRIPTION
For some reason /longest has stopped working in VLDC group, probably that's because some user have special markdown characters in name, that should probably fix it 