### PR TITLE
fix: make image buildable for m1 chip

### DIFF
--- a/compose/dev/Dockerfile
+++ b/compose/dev/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-slim
 
-RUN apt-get -y update && apt-get install -y ffmpeg
+RUN apt-get -y update && apt-get install -y ffmpeg build-essential
 
 ENV PYTHONPATH /app
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -15,7 +15,7 @@ services:
       - serving
     env_file:
       - ./.env
-    environment :
+    environment:
       - PYTHONPATH=./bot
     logging:
       options:


### PR DESCRIPTION
This fix allows to build image on m1 chip.

Could you check if it's still buildable for you @egregors  @getjump .