### PR TITLE
`roll` support for users with "admin" role

### DIFF
--- a/bot/skills/roll.py
+++ b/bot/skills/roll.py
@@ -396,6 +396,13 @@ def roll(update: Update, context: CallbackContext):
         # todo: https://github.com/vldc-hq/vldc-bot/issues/93
         #  if bot can't restrict user, user should be passed into towel-mode like state
 
+        # TODO: if user is admin, first revoke admin role: telegram.bot.Bot.promote_chat_member
+        #  * get user info (admin title, we should to store it to put it back when restriction is over)
+        #  * revoke admin role
+        #  * mute user as usual
+
+        # TODO: we need a way how to give admin role back to user when restriction time is over
+
         mute_min = get_mute_minutes(shots_remained)
         result = context.bot.send_message(
             update.effective_chat.id,


### PR DESCRIPTION
Solution for #93 (https://github.com/vldc-hq/vldc-bot/discussions/255) – the hard way.

- [ ] get user details (admin status, like “admin”, or “не сдался”) and save it for a time (to put it back when restriction time comms over)
  - [ ] update user DB model if it's necessary, required info (admin label) could be in `user.meta`, need to check it out
- [ ] revoke admin role: `telegram.bot.Bot.promote_chat_member`
- [ ] call `mute_user_for_time` as for a regular user
- [ ] find a way how to grand admin role back, when user comms back from the club