### PR TITLE
Add chat cmd handler with default chat_id filtering

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [[description]]
 name = "vldc-bot"
-version = "0.7.1"
+version = "0.8.0"
 description = "VLDC nyan bot ^_^"
 authors = [
     #tg

--- a/bot/mode.py
+++ b/bot/mode.py
@@ -9,12 +9,11 @@ from telegram.ext import (
     CallbackContext,
     Dispatcher,
     JobQueue,
-    Filters,
 )
 from telegram.ext.dispatcher import DEFAULT_GROUP
 
 from filters import admin_filter
-from config import get_group_chat_id
+from skills import ChatCommandHandler
 
 logger = logging.getLogger(__name__)
 
@@ -66,27 +65,23 @@ class Mode:
 
     def _add_on_off_handlers(self):
         self._dp.add_handler(
-            CommandHandler(
+            ChatCommandHandler(
                 f"{self.name}_on",
                 self._mode_on,
-                filters=Filters.chat(username=get_group_chat_id().strip("@"))
-                & admin_filter,
-                run_async=True,
+                filters=admin_filter,
             ),
             self.handlers_gr,
         )
         self._dp.add_handler(
-            CommandHandler(
+            ChatCommandHandler(
                 f"{self.name}_off",
                 self._mode_off,
-                filters=Filters.chat(username=get_group_chat_id().strip("@"))
-                & admin_filter,
-                run_async=True,
+                filters=admin_filter,
             ),
             self.handlers_gr,
         )
         self._dp.add_handler(
-            CommandHandler(f"{self.name}", self._mode_status, run_async=True),
+            ChatCommandHandler(f"{self.name}", self._mode_status),
             self.handlers_gr,
         )
 

--- a/bot/skills/__init__.py
+++ b/bot/skills/__init__.py
@@ -1,9 +1,13 @@
 import logging
-from typing import List, Dict, Callable, Tuple
+from typing import List, Dict, Callable, Tuple, Union
 
 import toml
 from telegram import Update
-from telegram.ext import CommandHandler, Updater, CallbackContext, Filters
+from telegram.ext import CommandHandler, Updater, CallbackContext, Filters, BaseFilter
+from telegram.ext.commandhandler import RT
+from telegram.ext.utils.types import CCT
+from telegram.utils.helpers import DefaultValue, DEFAULT_FALSE
+from telegram.utils.types import SLT
 
 from config import get_group_chat_id
 from filters import admin_filter
@@ -34,16 +38,61 @@ from skills.uwu import add_uwu
 logger = logging.getLogger(__name__)
 
 
+class ChatCommandHandler(CommandHandler):
+    """ChatCommandHandler is class-wrapper for `CommandHandler`. It provides default `chat_id` filtering.
+    `chat_id` takes from `config.get_group_chat_id() -> str` and it could be either
+    chat_username :: str (for public groups) or chat_id :: int (for private or public). So, this wrapper
+    support both type of `chat_id`, adds chat_id filtering and set `run_async` to True by default.
+    """
+
+    def __init__(
+        self,
+        command: SLT[str],
+        callback: Callable[[Update, CCT], RT],
+        filters: BaseFilter = None,
+        allow_edited: bool = None,
+        pass_args: bool = False,
+        pass_update_queue: bool = False,
+        pass_job_queue: bool = False,
+        pass_user_data: bool = False,
+        pass_chat_data: bool = False,
+        run_async: Union[bool, DefaultValue] = DEFAULT_FALSE,
+    ):
+
+        # chat_id filtering: accept messages only from particular chat
+        chat_id_or_name = get_group_chat_id()
+        try:
+            f = Filters.chat(chat_id=int(chat_id_or_name))
+        except ValueError:
+            f = Filters.chat(username=chat_id_or_name.strip("@"))
+        filters = f if filters is None else filters & f
+
+        # run commands async by default
+        if run_async == DEFAULT_FALSE:
+            run_async = True
+
+        super().__init__(
+            command,
+            callback,
+            filters,
+            allow_edited,
+            pass_args,
+            pass_update_queue,
+            pass_job_queue,
+            pass_user_data,
+            pass_chat_data,
+            run_async,
+        )
+
+
 def _add_version(upd: Updater, version_handlers_group: int):
     logger.info("register version handlers")
     dp = upd.dispatcher
     dp.add_handler(
-        CommandHandler(
+        ChatCommandHandler(
             "version",
             _version,
-            filters=Filters.chat(username=get_group_chat_id().strip("@"))
-            & admin_filter,
-            run_async=True,
+            filters=admin_filter,
         ),
         version_handlers_group,
     )

--- a/bot/skills/aoc_mode.py
+++ b/bot/skills/aoc_mode.py
@@ -1,23 +1,20 @@
 import logging
 from datetime import datetime, timedelta
 from functools import cmp_to_key
-
 from http import HTTPStatus
 
 import requests
-from config import get_group_chat_id, get_aoc_session
-
-from db.mongo import get_db
-from mode import Mode, OFF
-
 from pymongo.collection import Collection
-
 from telegram import Update, Bot
 from telegram.ext import (
     Updater,
     CallbackContext,
     JobQueue,
 )
+
+from config import get_group_chat_id, get_aoc_session
+from db.mongo import get_db
+from mode import Mode, OFF
 
 logger = logging.getLogger(__name__)
 

--- a/bot/skills/at_least_70k.py
+++ b/bot/skills/at_least_70k.py
@@ -1,7 +1,9 @@
 import logging
 
 from telegram import Update, User
-from telegram.ext import Updater, Dispatcher, CommandHandler, CallbackContext
+from telegram.ext import Updater, Dispatcher, CallbackContext
+
+from skills import ChatCommandHandler
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +17,7 @@ MSG = (
 def add_70k(upd: Updater, handlers_group: int):
     logger.info("registering 70k handler")
     dp: Dispatcher = upd.dispatcher
-    dp.add_handler(CommandHandler("70k", _70k, run_async=True), handlers_group)
+    dp.add_handler(ChatCommandHandler("70k", _70k), handlers_group)
 
 
 def _70k(update: Update, context: CallbackContext):

--- a/bot/skills/ban.py
+++ b/bot/skills/ban.py
@@ -2,9 +2,10 @@ import logging
 from typing import Union
 
 from telegram import Update, User
-from telegram.ext import Updater, CommandHandler, CallbackContext
+from telegram.ext import Updater, CallbackContext
 
 from mode import cleanup_queue_update
+from skills import ChatCommandHandler
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +13,7 @@ logger = logging.getLogger(__name__)
 def add_ban(upd: Updater, handlers_group: int):
     logger.info("registering ban handlers")
     dp = upd.dispatcher
-    dp.add_handler(CommandHandler("ban", ban, run_async=True), handlers_group)
+    dp.add_handler(ChatCommandHandler("ban", ban), handlers_group)
 
 
 def ban(update: Union[str, Update], context: CallbackContext):

--- a/bot/skills/banme.py
+++ b/bot/skills/banme.py
@@ -3,8 +3,9 @@ from datetime import timedelta
 from random import randint
 
 from telegram import Update, User, TelegramError
-from telegram.ext import Updater, CommandHandler, CallbackContext
+from telegram.ext import Updater, CallbackContext
 
+from skills import ChatCommandHandler
 from skills.mute import mute_user_for_time
 
 MUTE_MINUTES = 24 * 60  # 24h
@@ -21,7 +22,7 @@ def get_mute_minutes() -> timedelta:
 def add_banme(upd: Updater, handlers_group: int):
     logger.info("registering banme handlers")
     dp = upd.dispatcher
-    dp.add_handler(CommandHandler("banme", banme, run_async=True), handlers_group)
+    dp.add_handler(ChatCommandHandler("banme", banme), handlers_group)
 
 
 def banme(update: Update, context: CallbackContext):

--- a/bot/skills/coc.py
+++ b/bot/skills/coc.py
@@ -1,9 +1,10 @@
 import logging
 
 from telegram import Update
-from telegram.ext import Updater, CommandHandler, CallbackContext
+from telegram.ext import Updater, CallbackContext
 
 from mode import cleanup_queue_update
+from skills import ChatCommandHandler
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +14,7 @@ COC_LINK = "https://devfest.gdgvl.ru/ru/code-of-conduct/"
 def add_coc(upd: Updater, handlers_group: int):
     logger.info("registering CoC handler")
     dp = upd.dispatcher
-    dp.add_handler(CommandHandler("coc", coc, run_async=True), handlers_group)
+    dp.add_handler(ChatCommandHandler("coc", coc), handlers_group)
 
 
 def coc(update: Update, context: CallbackContext):

--- a/bot/skills/core.py
+++ b/bot/skills/core.py
@@ -1,7 +1,9 @@
 import logging
 
 from telegram import Update
-from telegram.ext import CommandHandler, Updater, CallbackContext
+from telegram.ext import Updater, CallbackContext
+
+from skills import ChatCommandHandler
 
 logger = logging.getLogger(__name__)
 
@@ -9,8 +11,8 @@ logger = logging.getLogger(__name__)
 def add_core(upd: Updater, core_handlers_group: int):
     logger.info("register smile-mode handlers")
     dp = upd.dispatcher
-    dp.add_handler(CommandHandler("start", start, run_async=True), core_handlers_group)
-    dp.add_handler(CommandHandler("help", help_, run_async=True), core_handlers_group)
+    dp.add_handler(ChatCommandHandler("start", start), core_handlers_group)
+    dp.add_handler(ChatCommandHandler("help", help_), core_handlers_group)
 
 
 def start(update: Update, _: CallbackContext):

--- a/bot/skills/fools.py
+++ b/bot/skills/fools.py
@@ -6,8 +6,8 @@ from google.cloud import translate
 from telegram import Update, User
 from telegram.error import BadRequest, TelegramError
 from telegram.ext import Updater, MessageHandler, Filters, CallbackContext
-from config import get_group_chat_id
 
+from config import get_group_chat_id
 from mode import Mode, OFF
 
 logger = logging.getLogger(__name__)

--- a/bot/skills/kozula.py
+++ b/bot/skills/kozula.py
@@ -4,9 +4,10 @@ from typing import Optional
 
 import requests
 from telegram import Update
-from telegram.ext import Updater, CommandHandler, CallbackContext
+from telegram.ext import Updater, CallbackContext
 
 from mode import cleanup_queue_update
+from skills import ChatCommandHandler
 from utils.cache import timed_lru_cache
 
 logger = logging.getLogger(__name__)
@@ -18,7 +19,7 @@ CBR_URL = "https://cbr.ru/scripts/XML_daily.asp"
 def add_kozula(upd: Updater, handlers_group: int):
     logger.info("registering tree handlers")
     dp = upd.dispatcher
-    dp.add_handler(CommandHandler("kozula", kozula, run_async=True), handlers_group)
+    dp.add_handler(ChatCommandHandler("kozula", kozula), handlers_group)
 
 
 @timed_lru_cache(ttl=3600)

--- a/bot/skills/length.py
+++ b/bot/skills/length.py
@@ -1,19 +1,16 @@
 import logging
 from typing import Optional, List, TypedDict
 
-from telegram import Update, User, Message
-from telegram.ext import Updater, CommandHandler, CallbackContext
-from telegram.ext.filters import Filters
-
-from mode import cleanup_queue_update
-from config import get_group_chat_id
-
-from skills.roll import _get_username
-
-from db.mongo import get_db
 import pymongo
 from pymongo.collection import Collection
 from pymongo.results import UpdateResult
+from telegram import Update, User, Message
+from telegram.ext import Updater, CallbackContext
+
+from db.mongo import get_db
+from mode import cleanup_queue_update
+from skills import ChatCommandHandler
+from skills.roll import _get_username
 
 logger = logging.getLogger(__name__)
 
@@ -27,21 +24,17 @@ def add_length(upd: Updater, handlers_group: int):
     logger.info("registering length handlers")
     dp = upd.dispatcher
     dp.add_handler(
-        CommandHandler(
+        ChatCommandHandler(
             "length",
             _length,
-            filters=Filters.chat(username=get_group_chat_id().strip("@")),
-            run_async=True,
         ),
         handlers_group,
     )
 
     dp.add_handler(
-        CommandHandler(
+        ChatCommandHandler(
             "longest",
             _longest,
-            filters=Filters.chat(username=get_group_chat_id().strip("@")),
-            run_async=True,
         ),
         handlers_group,
     )

--- a/bot/skills/mute.py
+++ b/bot/skills/mute.py
@@ -4,11 +4,11 @@ from random import choice
 from typing import List
 
 from telegram import Update, User, ChatPermissions, TelegramError
-from telegram.ext import Updater, CommandHandler, CallbackContext, Filters
+from telegram.ext import Updater, CallbackContext
 
 from filters import admin_filter
-from config import get_group_chat_id
 from mode import cleanup_queue_update
+from skills import ChatCommandHandler
 from utils.time import get_duration
 
 logger = logging.getLogger(__name__)
@@ -21,23 +21,19 @@ def add_mute(upd: Updater, handlers_group: int):
     logger.info("registering mute handlers")
     dp = upd.dispatcher
     dp.add_handler(
-        CommandHandler(
+        ChatCommandHandler(
             "mute",
             mute,
-            filters=Filters.chat(username=get_group_chat_id().strip("@"))
-            & admin_filter,
-            run_async=True,
+            filters=admin_filter,
         ),
         handlers_group,
     )
-    dp.add_handler(CommandHandler("mute", mute_self, run_async=True), handlers_group)
+    dp.add_handler(ChatCommandHandler("mute", mute_self), handlers_group)
     dp.add_handler(
-        CommandHandler(
+        ChatCommandHandler(
             "unmute",
             unmute,
-            filters=Filters.chat(username=get_group_chat_id().strip("@"))
-            & admin_filter,
-            run_async=True,
+            filters=admin_filter,
         ),
         handlers_group,
     )

--- a/bot/skills/nya.py
+++ b/bot/skills/nya.py
@@ -2,10 +2,10 @@ import logging
 
 from telegram import Update
 from telegram.error import BadRequest
-from telegram.ext import Updater, CommandHandler, CallbackContext, Filters
+from telegram.ext import Updater, CallbackContext
 
 from filters import admin_filter
-from config import get_group_chat_id
+from skills import ChatCommandHandler
 
 logger = logging.getLogger(__name__)
 
@@ -14,12 +14,10 @@ def add_nya(upd: Updater, handlers_group: int):
     logger.info("registering nya handlers")
     dp = upd.dispatcher
     dp.add_handler(
-        CommandHandler(
+        ChatCommandHandler(
             "nya",
             nya,
-            filters=Filters.chat(username=get_group_chat_id().strip("@"))
-            & admin_filter,
-            run_async=True,
+            filters=admin_filter,
         ),
         handlers_group,
     )

--- a/bot/skills/pr.py
+++ b/bot/skills/pr.py
@@ -1,7 +1,9 @@
 import logging
 
 from telegram import Update, User
-from telegram.ext import Updater, Dispatcher, CommandHandler, CallbackContext
+from telegram.ext import Updater, Dispatcher, CallbackContext
+
+from skills import ChatCommandHandler
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +17,7 @@ MSG = (
 def add_pr(upd: Updater, handlers_group: int):
     logger.info("registering PR handler")
     dp: Dispatcher = upd.dispatcher
-    dp.add_handler(CommandHandler("pr", _pr, run_async=True), handlers_group)
+    dp.add_handler(ChatCommandHandler("pr", _pr), handlers_group)
 
 
 def _pr(update: Update, context: CallbackContext):

--- a/bot/skills/prism.py
+++ b/bot/skills/prism.py
@@ -11,13 +11,13 @@ from telegram.ext import (
     MessageHandler,
     Filters,
     CallbackContext,
-    CommandHandler,
 )
 
+from config import get_group_chat_id
 from db.mongo import get_db
 from filters import admin_filter
-from config import get_group_chat_id
 from mode import cleanup_queue_update
+from skills import ChatCommandHandler
 
 logger = logging.getLogger(__name__)
 
@@ -50,12 +50,10 @@ def add_prism(upd: Updater, handlers_group: int):
     logger.info("register words handlers")
     dp = upd.dispatcher
     dp.add_handler(
-        CommandHandler(
+        ChatCommandHandler(
             "top",
             show_top,
-            filters=Filters.chat(username=get_group_chat_id().strip("@"))
-            & admin_filter,
-            run_async=True,
+            filters=admin_filter,
         ),
         handlers_group,
     )

--- a/bot/skills/roll.py
+++ b/bot/skills/roll.py
@@ -1,13 +1,12 @@
 import logging
 import os
+import re
 from datetime import datetime, timedelta
 from random import randint, choice
 from tempfile import gettempdir
 from threading import Lock
 from typing import List, Optional, Tuple, Dict
 from uuid import uuid4
-
-import re
 
 import pymongo
 from PIL import Image, ImageDraw, ImageFont
@@ -16,11 +15,12 @@ from telegram import Update, User, Message, ChatMember
 from telegram.ext import Updater, CommandHandler, MessageHandler, CallbackContext
 from telegram.ext.filters import Filters
 
+from config import get_group_chat_id
 from db.mongo import get_db
 from filters import admin_filter
 from mode import cleanup_queue_update
+from skills import ChatCommandHandler
 from skills.mute import mute_user_for_time
-from config import get_group_chat_id
 
 logger = logging.getLogger(__name__)
 
@@ -115,11 +115,9 @@ def add_roll(upd: Updater, handlers_group: int):
         MessageHandler(Filters.regex(MEME_REGEX), roll, run_async=True), handlers_group
     )
     dp.add_handler(
-        CommandHandler(
+        ChatCommandHandler(
             "gdpr_me",
             satisfy_GDPR,
-            filters=Filters.chat(username=get_group_chat_id().strip("@")),
-            run_async=True,
         ),
         handlers_group,
     )
@@ -134,22 +132,18 @@ def add_roll(upd: Updater, handlers_group: int):
         handlers_group,
     )
     dp.add_handler(
-        CommandHandler(
+        ChatCommandHandler(
             "htop",
             show_active_hussars,
-            filters=admin_filter
-            & Filters.chat(username=get_group_chat_id().strip("@")),
-            run_async=True,
+            filters=admin_filter,
         ),
         handlers_group,
     )
     dp.add_handler(
-        CommandHandler(
+        ChatCommandHandler(
             "wipe_hussars",
             wipe_hussars,
-            filters=admin_filter
-            & Filters.chat(username=get_group_chat_id().strip("@")),
-            run_async=True,
+            filters=admin_filter,
         ),
         handlers_group,
     )

--- a/bot/skills/since_mode.py
+++ b/bot/skills/since_mode.py
@@ -5,10 +5,11 @@ from typing import Dict, List
 
 from pymongo import MongoClient
 from pymongo.collection import Collection
-from telegram.ext import Updater, CommandHandler, Filters
+from telegram.ext import Updater
 
-from config import get_config, get_group_chat_id
+from config import get_config
 from mode import Mode
+from skills import ChatCommandHandler
 
 conf = get_config()
 
@@ -25,20 +26,16 @@ def add_since_mode(upd: Updater, handlers_group: int):
     logger.info("register since-mode handlers")
     dp = upd.dispatcher
     dp.add_handler(
-        CommandHandler(
+        ChatCommandHandler(
             "since",
             since_callback,
-            filters=Filters.chat(username=get_group_chat_id().strip("@")),
-            run_async=True,
         ),
         handlers_group,
     )
     dp.add_handler(
-        CommandHandler(
+        ChatCommandHandler(
             "since_list",
             since_list_callback,
-            filters=Filters.chat(username=get_group_chat_id().strip("@")),
-            run_async=True,
         ),
         handlers_group,
     )

--- a/bot/skills/still.py
+++ b/bot/skills/still.py
@@ -3,7 +3,9 @@ from datetime import datetime
 
 from telegram import Update
 from telegram.error import BadRequest
-from telegram.ext import Updater, CommandHandler, CallbackContext
+from telegram.ext import Updater, CallbackContext
+
+from skills import ChatCommandHandler
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +13,7 @@ logger = logging.getLogger(__name__)
 def add_still(upd: Updater, handlers_group: int):
     logger.info("registering still handlers")
     dp = upd.dispatcher
-    dp.add_handler(CommandHandler("still", still, run_async=True), handlers_group)
+    dp.add_handler(ChatCommandHandler("still", still), handlers_group)
 
 
 def to_2k_year(year: int):

--- a/bot/skills/tree.py
+++ b/bot/skills/tree.py
@@ -1,7 +1,9 @@
 import logging
 
 from telegram import Update
-from telegram.ext import Updater, CommandHandler, CallbackContext
+from telegram.ext import Updater, CallbackContext
+
+from skills import ChatCommandHandler
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +13,7 @@ AOC_LEADERBOARD_LINK = "https://adventofcode.com/2021/leaderboard/private/view/4
 def add_tree(upd: Updater, handlers_group: int):
     logger.info("registering tree handlers")
     dp = upd.dispatcher
-    dp.add_handler(CommandHandler("tree", tree, run_async=True), handlers_group)
+    dp.add_handler(ChatCommandHandler("tree", tree), handlers_group)
 
 
 def tree(update: Update, context: CallbackContext):

--- a/bot/skills/trusted_mode.py
+++ b/bot/skills/trusted_mode.py
@@ -4,12 +4,12 @@ from typing import Optional
 
 from pymongo.collection import Collection
 from telegram import Update, User
-from telegram.ext import Updater, CommandHandler, CallbackContext, Filters
+from telegram.ext import Updater, CallbackContext
 
-from config import get_group_chat_id
 from db.mongo import get_db
 from filters import admin_filter
 from mode import Mode, ON
+from skills import ChatCommandHandler
 
 logger = logging.getLogger(__name__)
 
@@ -47,22 +47,18 @@ def add_trusted_mode(upd: Updater, handlers_group: int):
     logger.info("register trusted-mode handlers")
     dp = upd.dispatcher
     dp.add_handler(
-        CommandHandler(
+        ChatCommandHandler(
             "trust",
             trust_callback,
-            filters=Filters.chat(username=get_group_chat_id().strip("@"))
-            & admin_filter,
-            run_async=True,
+            filters=admin_filter,
         ),
         handlers_group,
     )
     dp.add_handler(
-        CommandHandler(
+        ChatCommandHandler(
             "untrust",
             untrust_callback,
-            filters=Filters.chat(username=get_group_chat_id().strip("@"))
-            & admin_filter,
-            run_async=True,
+            filters=admin_filter,
         ),
         handlers_group,
     )


### PR DESCRIPTION
Closes #257 

- [x] Custom wrapper for `CommandHandler`
  - [x] support both chat_id (int) and chat_username (str)
  - [x] `chat_id` filtering by default
  - [x] `run_async=True` by default 