### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/nayn_bot.yml
+++ b/.github/workflows/nayn_bot.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Test with pytest
       run: export PYTHONPATH=./bot && pytest
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: vldc-hq/vldc-bot/bot
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/nayn_bot_dev.yml
+++ b/.github/workflows/nayn_bot_dev.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Test with pytest
       run: export PYTHONPATH=./bot && pytest
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: vldc-hq/vldc-bot/bot_dev
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore