### PR TITLE
fix cancel jobs

### DIFF
--- a/bot/skills/buktopuha.py
+++ b/bot/skills/buktopuha.py
@@ -153,7 +153,7 @@ game = Buktopuha()
 
 def stop_jobs(update: Update, context: CallbackContext, names: list[str]):
     for name in names:
-        for job in context.get_jobs_by_name(name):
+        for job in context.job_queue.get_jobs_by_name(name):
             job.schedule_removal()
 
 


### PR DESCRIPTION
Missed `job_queue` part, so jobs are not properly canceled:

```
2023-04-05 07:23:21,831 - telegram.ext.dispatcher - ERROR - No error handlers are registered, logging exception.
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/telegram/ext/utils/promise.py", line 96, in run
    self._result = self.pooled_function(*self.args, **self.kwargs)
  File "/app/bot/skills/buktopuha.py", line 172, in check_for_answer
    stop_jobs(update, context, [f"{j}-{word}" for j in ["hint1", "hint2", "end"]])
  File "/app/bot/skills/buktopuha.py", line 156, in stop_jobs
    for job in context.get_jobs_by_name(name):
AttributeError: 'CallbackContext' object has no attribute 'get_jobs_by_name'
```