### PR TITLE
Feature/cleanup-buk

### DIFF
--- a/bot/skills/buktopuha.py
+++ b/bot/skills/buktopuha.py
@@ -274,7 +274,6 @@ def start_buktopuha(update: Update, context: CallbackContext):
             update.message,
             result,
             10,
-            remove_reply=True,
         )
         game.start("")  # set last_game time, to dissallow immediate reattempts
         return


### PR DESCRIPTION
Do some messages cleanup (hints mostly).
Can't cleanup all messages because we can't distinguish between wrong buktopuha guesses and general chat.
Also can't delete bot buktopuha question because user quesses in the chat log would not make sense if we remove the question.

Made some messages more terse. E.g. removing "Starting the BukToPuHa" header if the game was played recently.