### PR TITLE
use chat completions api

### DIFF
--- a/bot/skills/buktopuha.py
+++ b/bot/skills/buktopuha.py
@@ -328,11 +328,9 @@ def check_for_answer(update: Update, context: CallbackContext):
 
 
 def generate_question(prompt, word) -> str:
-    model = random.choice(
-        ["gpt-3.5-turbo-instruct", "gpt-4-1106-preview", "gemini-pro"]
-    )
+    model = random.choice(["gpt-3.5-turbo", "gpt-4-1106-preview", "gemini-pro"])
     if model.startswith("gpt"):
-        response = openai.Completion.create(
+        response = openai.ChatCompletion.create(
             model=model,
             prompt=prompt,
             temperature=0.9,


### PR DESCRIPTION
OpenAI Completions API is moved to "legacy". New models like gpt-4-turbo use ChatCompletions instead.
https://platform.openai.com/docs/api-reference/chat