### PR TITLE
message is not a str

### DIFF
--- a/bot/skills/chat.py
+++ b/bot/skills/chat.py
@@ -38,13 +38,13 @@ class Nyan:
     def registerMessage(self, update: Update, context: CallbackContext):
         if update.message is None:
             return
-        if update.message[0] == "/":
+        if update.message.text.starts_with("/"):
             return
         with self.lock:
             self.memory.append(
                 (
                     datetime.now(),
-                    f"{update.effective_user.full_name}: {update.message}",
+                    f"{update.effective_user.full_name}: {update.message.text}",
                 ),
             )
 


### PR DESCRIPTION
Looks like nyan is silent because of this line:

```python
update.message[0] == "/"
```

`message` is an object and not a string,